### PR TITLE
修改发送图片消息和表情消息失败的问题、使用最新网页微信域名

### DIFF
--- a/weixin.py
+++ b/weixin.py
@@ -81,8 +81,8 @@ class WebWeixin(object):
     def __init__(self):
         self.DEBUG = False
         self.uuid = ''
-        self.base_uri = ''
-        self.redirect_uri = ''
+        self.base_uri = 'https://wx.qq.com/cgi-bin/mmwebwx-bin'
+        self.redirect_uri = 'https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxnewloginpag'
         self.uin = ''
         self.sid = ''
         self.skey = ''
@@ -133,7 +133,7 @@ class WebWeixin(object):
             self.autoOpen = config['autoOpen']
 
     def getUUID(self):
-        url = 'https://login.weixin.qq.com/jslogin'
+        url = 'https://login.wx.qq.com/jslogin'
         params = {
             'appid': self.appid,
             'fun': 'new',
@@ -168,7 +168,7 @@ class WebWeixin(object):
 
     def waitForLogin(self, tip=1):
         time.sleep(tip)
-        url = 'https://login.weixin.qq.com/cgi-bin/mmwebwx-bin/login?tip=%s&uuid=%s&_=%s' % (
+        url = 'https://login.wx.qq.com/cgi-bin/mmwebwx-bin/login?tip=%s&uuid=%s&_=%s' % (
             tip, self.uuid, int(time.time()))
         data = self._get(url)
         pm = re.search(r'window.code=(\d+);', data)
@@ -245,7 +245,7 @@ class WebWeixin(object):
 
     def webwxgetcontact(self):
         SpecialUsers = self.SpecialUsers
-        print self.base_uri
+        #print self.base_uri
         url = self.base_uri + '/webwxgetcontact?pass_ticket=%s&skey=%s&r=%s' % (
             self.pass_ticket, self.skey, int(time.time()))
         dic = self._post(url, {})
@@ -390,7 +390,7 @@ class WebWeixin(object):
         return dic['BaseResponse']['Ret'] == 0
 
     def webwxuploadmedia(self, image_name):
-        url = 'https://file2.wx.qq.com/cgi-bin/mmwebwx-bin/webwxuploadmedia?f=json'
+        url = 'https://file.wx.qq.com/cgi-bin/mmwebwx-bin/webwxuploadmedia?f=json'
         # 计数器
         self.media_count = self.media_count + 1
         # 文件名
@@ -450,9 +450,9 @@ class WebWeixin(object):
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Accept-Language': 'en-US,en;q=0.5',
             'Accept-Encoding': 'gzip, deflate',
-            'Referer': 'https://wx2.qq.com/',
+            'Referer': 'https://wx.qq.com/',
             'Content-Type': multipart_encoder.content_type,
-            'Origin': 'https://wx2.qq.com',
+            'Origin': 'https://wx.qq.com',
             'Connection': 'keep-alive',
             'Pragma': 'no-cache',
             'Cache-Control': 'no-cache'
@@ -465,7 +465,8 @@ class WebWeixin(object):
         return None
 
     def webwxsendmsgimg(self, user_id, media_id):
-        url = 'https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxsendmsgimg?fun=async&f=json&pass_ticket=%s' % self.pass_ticket
+        url = self.base_uri + \
+            '/webwxsendmsgimg?fun=async&f=json&pass_ticket=%s' % self.pass_ticket
         clientMsgId = str(int(time.time() * 1000)) + \
             str(random.random())[:5].replace('.', '')
         data_json = {
@@ -486,7 +487,8 @@ class WebWeixin(object):
         return dic['BaseResponse']['Ret'] == 0
 
     def webwxsendmsgemotion(self, user_id, media_id):
-        url = 'https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxsendemoticon?fun=sys&f=json&pass_ticket=%s' % self.pass_ticket
+        url = self.base_uri + \
+            '/webwxsendemoticon?fun=sys&f=json&pass_ticket=%s' % self.pass_ticket
         clientMsgId = str(int(time.time() * 1000)) + \
             str(random.random())[:5].replace('.', '')
         data_json = {

--- a/weixin.py
+++ b/weixin.py
@@ -313,13 +313,14 @@ class WebWeixin(object):
 
     def testsynccheck(self):
         SyncHost = [
-            'webpush.weixin.qq.com',
-            'webpush2.weixin.qq.com',
-            'webpush.wechat.com',
-            'webpush1.wechat.com',
-            'webpush2.wechat.com',
-            'webpush1.wechatapp.com',
+            #'webpush.weixin.qq.com',
+            #'webpush2.weixin.qq.com',
+            #'webpush.wechat.com',
+            #'webpush1.wechat.com',
+            #'webpush2.wechat.com',
+            #'webpush1.wechatapp.com',
             # 'webpush.wechatapp.com'
+            'webpush.wx.qq.com'
         ]
         for host in SyncHost:
             self.syncHost = host


### PR DESCRIPTION
修改发送图片消息和表情消息失败的问题
使用最新网页微信域名,上传媒体文件修改为file域名
