### PR TITLE
修复windows上出现的错误以及乱码问题

### DIFF
--- a/weixin.py
+++ b/weixin.py
@@ -1151,10 +1151,10 @@ if sys.stdout.encoding == 'cp936':
 
 
 if __name__ == '__main__':
-
     logger = logging.getLogger(__name__)
-    import coloredlogs
-    coloredlogs.install(level='DEBUG')
+    if not sys.platform.startswith('win'):
+        import coloredlogs
+        coloredlogs.install(level='DEBUG')
 
     webwx = WebWeixin()
     webwx.start()

--- a/weixin.py
+++ b/weixin.py
@@ -958,8 +958,12 @@ class WebWeixin(object):
             print '[*] 自动回复模式 ... 关闭'
             logging.debug('[*] 自动回复模式 ... 关闭')
 
-        listenProcess = multiprocessing.Process(target=self.listenMsgMode)
-        listenProcess.start()
+        if sys.platform.startswith('win'):
+            import thread
+            thread.start_new_thread(self.listenMsgMode())
+        else:
+            listenProcess = multiprocessing.Process(target=self.listenMsgMode)
+            listenProcess.start()
 
         while True:
             text = raw_input('')


### PR DESCRIPTION
1、改用thread的方式代替multiprocessing
2、window系统删除colorlogs的内容
