### PR TITLE
fix exception when message contains :<br/>

### DIFF
--- a/weixin.py
+++ b/weixin.py
@@ -281,7 +281,7 @@ class WebWeixin(object):
             elif Contact['UserName'] in SpecialUsers:  # 特殊账号
                 ContactList.remove(Contact)
                 self.SpecialUsersList.append(Contact)
-            elif Contact['UserName'].find('@@') != -1:  # 群聊
+            elif '@@' in Contact['UserName']:  # 群聊
                 ContactList.remove(Contact)
                 self.GroupList.append(Contact)
             elif Contact['UserName'] == self.User['UserName']:  # 自己
@@ -696,8 +696,8 @@ class WebWeixin(object):
 
             if msg['raw_msg']['FromUserName'][:2] == '@@':
                 # 接收到来自群的消息
-                if re.search(":<br/>", content, re.IGNORECASE):
-                    [people, content] = content.split(':<br/>')
+                if ":<br/>" in content:
+                    [people, content] = content.split(':<br/>', 1)
                     groupName = srcName
                     srcName = self.getUserRemarkName(people)
                     dstName = 'GROUP'


### PR DESCRIPTION
- When message contains ':<br\/>', the following exception will be raised
`Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "weixin.py", line 850, in listenMsgMode
    elif selector == '6':
  File "weixin.py", line 748, in handleMsg
    self._showMsg(raw_msg)
  File "weixin.py", line 700, in _showMsg
    [people, content] = content.split(':<br/>', 1)
ValueError: too many values to unpack
`

- string find should always use `in`