### PR TITLE
fix: dev: 增加命令行显示二维码功能及开关 & 使用timeout参数提升微信初始化时线路检测速度 & 解决常见ssl错误

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ qrcode
 requests
 six
 requests_toolbelt
+pyqrcode
+certifi


### PR DESCRIPTION
* 1. 增加命令行显示二维码功能及开关
       可通过WebWeixin类__init__中 commandLineQRCode 选项开启
       开启后，将使用命令行展示二维码，代替原有的操作系统系统图片展示形式
       需注意：
       a.
当您在使用中出现二维码过宽或过窄问题，请调整_showCommandLineQRCode函数中的enableCmdQR参数来解决二维码比例问题
       b. 当您在使用中出现二维码倾斜问题，这个问题出自于您的终端字体设置。
* 2.
此工程在初始化过程中经常出现卡在”同步线路测试”处，原因在于以get形式测试线路没有带timeout参数，导致卡在get请求中无法自动跳出。本次
修改增加了urllib.request.urlopen函数的timeout参数，以快速跳出无效的检测。此外，此处修改不影响其他函数调用类内_ge
t函数。
* 3.
requirements缺少certifi模块，此模块在python3安装中为选装。因此导致部分开发者系统中无此模块导致的启动错误（小概率事件）

* 4. 致敬项目作者。提议：请在未来开发中
更多遵守Python代码书写\命名规范（PEP-8），以使得项目更容易被阅读，同时忽略高级Python编辑器的书写规范Warning。再次致敬。